### PR TITLE
feat: Automatisierung mit Stale Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: Mark stale issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Läuft täglich um Mitternacht
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark stale issues
+        uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-message: "Diese Issue wurde als inaktiv markiert und wird bald geschlossen."
+          close-issue-message: "Die Issue wurde geschlossen, da sie seit 7 Tagen inaktiv war."

--- a/docs/03_merge.md
+++ b/docs/03_merge.md
@@ -1,2 +1,3 @@
 # Merge Konflikt A
 Dies ist die Version A der Datei.
+Für Version A


### PR DESCRIPTION
Diese Pull Request fügt eine GitHub Action hinzu, die inaktive Issues und Pull Requests nach 30 Tagen als „stale“ markiert und nach weiteren 7 Tagen automatisch schliesst. Dadurch bleibt das Repository aufgeräumt und alte, inaktive Issues werden nicht übersehen.